### PR TITLE
Allow GuildData and UserData creation by _id

### DIFF
--- a/bloxlink_lib/database.py
+++ b/bloxlink_lib/database.py
@@ -4,7 +4,7 @@ import asyncio
 import datetime
 import json
 from os.path import exists
-from typing import Type, TYPE_CHECKING, Any
+from typing import Type, Any
 
 from motor.motor_asyncio import AsyncIOMotorClient
 from redis.asyncio import Redis
@@ -171,6 +171,7 @@ async def update_item(domain: str, item_id: str, **aspects) -> None:
     unset_aspects = {}
     set_aspects = {}
 
+    # arrange items into set and unset (delete)
     for key, val in aspects.items():
         if val is None:
             unset_aspects[key] = ""

--- a/bloxlink_lib/models/guilds.py
+++ b/bloxlink_lib/models/guilds.py
@@ -69,7 +69,7 @@ class GuildRestriction(BaseModel):
 class GuildData(BaseModel):
     """Representation of the stored settings for a guild"""
 
-    id: int
+    id: Annotated[int, Field(alias="_id")]
     binds: Annotated[list[binds_module.GuildBind], Field(default_factory=list)]
 
     @field_validator("binds", mode="before")

--- a/bloxlink_lib/models/users.py
+++ b/bloxlink_lib/models/users.py
@@ -37,7 +37,7 @@ class UserData(BaseModel):
         robloxAccounts (dict): All of the user's linked accounts, and any guild specific verifications.
     """
 
-    id: int
+    id: Annotated[int, Field(alias="_id")]
     robloxID: str | None = None
     robloxAccounts: dict = Field(
         default_factory=lambda: {"accounts": [], "guilds": {}, "confirms": {}}


### PR DESCRIPTION
Allows initializing `UserData` and `GuildData` with the raw MongoDB data