### PR TITLE
Unset null fields from the guild schema

### DIFF
--- a/bloxlink_lib/models/migrators.py
+++ b/bloxlink_lib/models/migrators.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from bloxlink_lib.models.schemas.guilds import (  # pylint: disable=no-name-in-module
     GuildRestriction,
 )
+from bloxlink_lib.models import BaseModel
 
 
 def migrate_restrictions(
@@ -42,3 +43,14 @@ def migrate_disallow_ban_evaders(disallow_ban_evaders: bool | str | None) -> boo
         return disallow_ban_evaders
 
     return disallow_ban_evaders in ("ban", "kick")
+
+
+def unset_nulls(base_model: BaseModel, base_model_data: dict) -> dict:
+    """Remove null fields from the data before Pydantic validates the model"""
+
+    if isinstance(base_model_data, dict):
+        for field_name in base_model.model_fields:
+            if field_name in base_model_data and base_model_data[field_name] is None:
+                del base_model_data[field_name]  # unset the field
+
+    return base_model_data

--- a/bloxlink_lib/models/schemas/guilds.py
+++ b/bloxlink_lib/models/schemas/guilds.py
@@ -1,5 +1,5 @@
-from typing import Self, Type, Literal, Annotated
-from pydantic import Field, field_validator
+from typing import Any, Self, Type, Literal, Annotated
+from pydantic import Field, field_validator, model_validator
 from bloxlink_lib.models.base import (
     PydanticList,
     BaseModel,
@@ -83,25 +83,25 @@ class GuildData(BaseSchema):
     binds: Annotated[list[GuildBind], Field(default_factory=list)]
 
     verifiedRoleEnabled: bool = True
-    verifiedRoleName: str | None = "Verified"  # deprecated
+    verifiedRoleName: str = "Verified"  # deprecated
     verifiedRole: str = None
 
     unverifiedRoleEnabled: bool = True
-    unverifiedRoleName: str | None = "Unverified"  # deprecated
+    unverifiedRoleName: str = "Unverified"  # deprecated
     unverifiedRole: str = None
 
-    verifiedDM: str | None = (
+    verifiedDM: str = (
         ":wave: Welcome to **{server-name}**, {roblox-name}! Visit <{verify-url}> to change your account.\nFind more Roblox Communities at https://blox.link/communities !"
     )
 
     ageLimit: int = None
     autoRoles: bool = True
     autoVerification: bool = True
-    disallowAlts: bool | None = False
-    disallowBanEvaders: bool | None = False
-    banRelatedAccounts: bool | None = False
-    unbanRelatedAccounts: bool | None = False
-    dynamicRoles: bool | None = True
+    disallowAlts: bool = False
+    disallowBanEvaders: bool = False
+    banRelatedAccounts: bool = False
+    unbanRelatedAccounts: bool = False
+    dynamicRoles: bool = True
     groupLock: PydanticDict[str, GroupLock] = None
     highTrafficServer: bool = False
     allowOldRoles: bool = False
@@ -125,11 +125,22 @@ class GuildData(BaseSchema):
     premium: PydanticDict = Field(default_factory=PydanticDict)  # deprecated
 
     # Old bind fields.
-    roleBinds: PydanticDict | None = None
+    roleBinds: PydanticDict = None
     groupIDs: PydanticDict = None
     migratedBindsToV4: bool = False
 
     # field converters
+    @model_validator(mode="before")
+    @classmethod
+    def handle_nulls(cls, data: Any) -> Any:
+        """Remove null fields from the data"""
+
+        from bloxlink_lib.models.migrators import (
+            unset_nulls,
+        )
+
+        return unset_nulls(cls, data)
+
     @field_validator("binds", mode="before")
     @classmethod
     def transform_binds(cls: Type[Self], binds: list) -> list[GuildBind]:


### PR DESCRIPTION
Removes null fields from the database guild schema since these should be unset.

Example: `GuildData(id="123", verifiedDM=None)` -> `GuildData(id="123")`