### PR TITLE
Use DatabaseDomain enum for fetch_item collection name

### DIFF
--- a/bloxlink_lib/models/schemas/guilds.py
+++ b/bloxlink_lib/models/schemas/guilds.py
@@ -288,7 +288,7 @@ async def fetch_guild_data(
     else:
         guild_id = str(guild)
 
-    return await fetch_item("guilds", GuildData, guild_id, *aspects)
+    return await fetch_item(GuildData, guild_id, *aspects)
 
 
 async def update_guild_data(

--- a/bloxlink_lib/models/schemas/users.py
+++ b/bloxlink_lib/models/schemas/users.py
@@ -45,7 +45,7 @@ async def fetch_user_data(
     else:
         user_id = str(user)
 
-    return await fetch_item("users", UserData, user_id, *aspects)
+    return await fetch_item(UserData, user_id, *aspects)
 
 
 async def update_user_data(


### PR DESCRIPTION
Updates `fetch_item` to use  `database_domain()` for retrieving the MongoDB collection name to use.