### PR TITLE
Switch to built in http.HTTPStatus

### DIFF
--- a/bloxlink_lib/exceptions.py
+++ b/bloxlink_lib/exceptions.py
@@ -1,3 +1,6 @@
+from http import HTTPStatus
+
+
 class BloxlinkException(Exception):
     """Base exception for Bloxlink."""
 
@@ -6,7 +9,7 @@ class BloxlinkException(Exception):
         message: str | None = None,
         *,
         send_ephemeral: bool = False,
-        status_code: int = 400
+        status_code: int = HTTPStatus.BAD_REQUEST,
     ):
         self.message = message
         self.send_ephemeral = send_ephemeral  # Used exclusively by the bot to send the message as an ephemeral message. Not shown in web responses.
@@ -18,27 +21,41 @@ class BloxlinkException(Exception):
 class Message(BloxlinkException):
     """Generic exception to communicate some message to the user. Not necessarily an error."""
 
+    status_code = HTTPStatus.OK
+
 
 # ERRORS
 class Error(BloxlinkException):
     """Generic error."""
 
+    status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+
 
 class RobloxNotFound(Error):
     """Raised when a Roblox entity is not found."""
+
+    status_code = HTTPStatus.NOT_FOUND
 
 
 class RobloxAPIError(Error):
     """Raised when the Roblox API returns an error."""
 
+    status_code = HTTPStatus.BAD_REQUEST
+
 
 class RobloxDown(Error):
     """Raised when the Roblox API is down."""
+
+    status_code = HTTPStatus.SERVICE_UNAVAILABLE
 
 
 class UserNotVerified(Error):
     """Raised when a user is not verified."""
 
+    status_code = HTTPStatus.FORBIDDEN
+
 
 class BloxlinkForbidden(Error):
     """Raised when a user lacks permissions."""
+
+    status_code = HTTPStatus.FORBIDDEN

--- a/bloxlink_lib/models/base/serializable.py
+++ b/bloxlink_lib/models/base/serializable.py
@@ -119,6 +119,9 @@ class GuildSerializable(BaseModel):
 
         match role_type:
             case RoleSerializable():
+                if isinstance(roles, dict):
+                    return {Snowflake(r.id): r for r in roles.values()}
+
                 return {Snowflake(r.id): r for r in roles}
             case dict():
                 if isinstance(roles, dict):


### PR DESCRIPTION
Ran into a circular import when I wanted to add status codes to the exceptions, so it's finally time to remove our StatusCodes enum and use the built-in one