### PR TITLE
Add shorter nicknames

### DIFF
--- a/bloxlink_lib/models/roblox/binds.py
+++ b/bloxlink_lib/models/roblox/binds.py
@@ -200,7 +200,7 @@ async def parse_template(
                     )
 
                     if roleset_brackets_match:
-                        group_roleset_name = f"[{roleset_brackets_match.group(1)}]"
+                        group_roleset_name = roleset_brackets_match.group(1)
 
             else:
                 group_roleset_name = "Guest"

--- a/bloxlink_lib/models/roblox/binds.py
+++ b/bloxlink_lib/models/roblox/binds.py
@@ -29,6 +29,7 @@ ARBITRARY_GROUP_TEMPLATE = re.compile(r"\{group-rank-(.*?)\}")
 
 ARBITRARY_GROUP_TEMPLATE = re.compile(r"\{group-rank-(.*?)\}")
 NICKNAME_TEMPLATE_REGEX = re.compile(r"\{(.*?)\}")
+ROLESET_BRACKET_TEMPLATE = re.compile(r"\[(.*)\]")
 
 
 class RobloxUserNicknames(Enum):
@@ -131,6 +132,7 @@ async def parse_template(
     roblox_user: RobloxUser | None = None,
     template: str = None,
     potential_binds: list[GuildBind] | None = None,
+    shorter_nicknames=False,
     trim_nickname=True,
 ) -> str | None:
     """
@@ -191,6 +193,14 @@ async def parse_template(
                 group_roleset_name = roblox_user.groups[
                     group_bind.criteria.id
                 ].role.name
+
+                if shorter_nicknames:
+                    roleset_brackets_match = ROLESET_BRACKET_TEMPLATE.search(
+                        group_roleset_name
+                    )
+
+                    if roleset_brackets_match:
+                        group_roleset_name = f"[{roleset_brackets_match.group(1)}]"
 
             else:
                 group_roleset_name = "Guest"

--- a/bloxlink_lib/models/schemas/guilds.py
+++ b/bloxlink_lib/models/schemas/guilds.py
@@ -144,6 +144,7 @@ class GuildData(BaseSchema):
     banRelatedAccounts: bool | None = False
     unbanRelatedAccounts: bool | None = False
     dynamicRoles: bool | None = True
+    shorterNicknames: bool | None = False
     groupLock: PydanticDict[str, GroupLock] | None = None
     highTrafficServer: bool | None = False
     allowOldRoles: bool | None = False

--- a/tests/unit/fixtures/groups.py
+++ b/tests/unit/fixtures/groups.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, auto
 from typing import Callable
 import pytest
 from bloxlink_lib import (
@@ -28,10 +28,10 @@ class GroupRolesets(Enum):
     """The Rolesets for the test group"""
 
     GUEST = 0
-    MEMBER = 1
-    OFFICER = 2
-    COMMANDER = 3
-    ADMIN = 4
+    MEMBER = auto()
+    OFFICER = auto()
+    COMMANDER = auto()
+    ADMIN = auto()
 
 
 GroupRolesetsType = dict[int, GroupRoleset]

--- a/tests/unit/fixtures/users.py
+++ b/tests/unit/fixtures/users.py
@@ -16,7 +16,13 @@ from .groups import GroupRolesets
 from .guilds import GuildRoles
 from .assets import MockAssets
 
-__all__ = ["MockUserData", "MockUser", "mock_user", "test_group_member"]
+__all__ = [
+    "MockUserData",
+    "MockUser",
+    "mock_user",
+    "test_group_member",
+    "test_group_member_bracketed_roleset",
+]
 
 
 class MockUserData(BaseModel):
@@ -170,6 +176,35 @@ def test_group_member(
         username="john",
         guild=test_guild,
         groups={test_group.id: RobloxUserGroup(group=test_group, role=member_roleset)},
+    )
+
+    return user
+
+
+@pytest.fixture()
+def test_group_member_bracketed_roleset(
+    mocker,
+    test_guild: GuildSerializable,
+    test_group: RobloxGroup,
+) -> MockUser:
+    """Test Discord Member model with a bracketed roleset"""
+
+    user = mock_user(
+        mocker,
+        verified=True,
+        username="john",
+        guild=test_guild,
+        groups={
+            test_group.id: RobloxUserGroup(
+                group=test_group,
+                role=GroupRoleset(
+                    name="[L1] Recruit",
+                    rank=1,
+                    id=1,
+                    memberCount=1,
+                ),
+            )
+        },
     )
 
     return user

--- a/tests/unit/test_nicknames.py
+++ b/tests/unit/test_nicknames.py
@@ -1,9 +1,13 @@
 from typing import TYPE_CHECKING
 import pytest
+from pytest_mock import MockerFixture
 from bloxlink_lib.models.roblox.binds import parse_template
+from bloxlink_lib.models.binds import BindCriteria, GroupBindData
+from bloxlink_lib.models.roblox.groups import RobloxGroup
+from tests.unit.utils.bind_helpers import nickname_formatter, mock_bind
 
 # fixtures
-from .fixtures import NicknameTestCaseData, MockUser
+from .fixtures import NicknameTestCaseData, MockUser, NicknameTestData
 
 if TYPE_CHECKING:
     from bloxlink_lib import GuildSerializable, RobloxUser, MemberSerializable
@@ -78,4 +82,60 @@ class TestNicknames:
 
         assert (
             nickname == generic_template_test_data.expected_nickname
+        ), f"Expected nickname to be {expected_nickname}, got {nickname}"
+
+    @pytest.mark.asyncio_concurrent(group="nickname_generic_tests")
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            NicknameTestData(
+                nickname_template="[{group-rank}] {roblox-name}",
+                expected_nickname="[L1] {roblox_user.username}",
+                include_discord_user=True,
+                include_roblox_user=False,
+            ),
+        ],
+    )
+    async def test_shorter_nicknames(
+        self,
+        test_guild: "GuildSerializable",
+        test_group: RobloxGroup,
+        test_group_member_bracketed_roleset: MockUser,
+        test_case: NicknameTestData,
+        mocker: MockerFixture,
+    ):
+        """Test that templates with brackets are parsed correctly if shorter nicknames are enabled."""
+
+        expected_nickname = test_case.expected_nickname
+        nickname_template = test_case.nickname_template
+
+        expected_nickname = nickname_formatter(
+            expected_nickname_format=expected_nickname,
+            roblox_user=test_group_member_bracketed_roleset.roblox_user,
+            discord_user=test_group_member_bracketed_roleset.discord_user,
+            guild=test_guild,
+        )
+
+        group_bind = mock_bind(
+            mocker,
+            discord_roles=[],
+            criteria=BindCriteria(
+                type="group", id=test_group.id, group=GroupBindData(everyone=True)
+            ),
+            entity=test_group,
+        )
+
+        nickname = await parse_template(
+            guild_id=test_guild.id,
+            guild_name=test_guild.name,
+            member=test_group_member_bracketed_roleset.discord_user,
+            template=nickname_template,
+            potential_binds=[group_bind],
+            roblox_user=test_group_member_bracketed_roleset.roblox_user,
+            trim_nickname=False,  # Parse the entire template
+            shorter_nicknames=True,
+        )
+
+        assert (
+            nickname == expected_nickname
         ), f"Expected nickname to be {expected_nickname}, got {nickname}"

--- a/tests/unit/test_nicknames.py
+++ b/tests/unit/test_nicknames.py
@@ -94,6 +94,12 @@ class TestNicknames:
                 include_discord_user=True,
                 include_roblox_user=False,
             ),
+            NicknameTestData(
+                nickname_template="{roblox-name}",
+                expected_nickname="{roblox_user.username}",
+                include_discord_user=True,
+                include_roblox_user=False,
+            ),
         ],
     )
     async def test_shorter_nicknames(
@@ -105,6 +111,62 @@ class TestNicknames:
         mocker: MockerFixture,
     ):
         """Test that templates with brackets are parsed correctly if shorter nicknames are enabled."""
+
+        expected_nickname = test_case.expected_nickname
+        nickname_template = test_case.nickname_template
+
+        expected_nickname = nickname_formatter(
+            expected_nickname_format=expected_nickname,
+            roblox_user=test_group_member_bracketed_roleset.roblox_user,
+            discord_user=test_group_member_bracketed_roleset.discord_user,
+            guild=test_guild,
+        )
+
+        group_bind = mock_bind(
+            mocker,
+            discord_roles=[],
+            criteria=BindCriteria(
+                type="group", id=test_group.id, group=GroupBindData(everyone=True)
+            ),
+            entity=test_group,
+        )
+
+        nickname = await parse_template(
+            guild_id=test_guild.id,
+            guild_name=test_guild.name,
+            member=test_group_member_bracketed_roleset.discord_user,
+            template=nickname_template,
+            potential_binds=[group_bind],
+            roblox_user=test_group_member_bracketed_roleset.roblox_user,
+            trim_nickname=False,  # Parse the entire template
+            shorter_nicknames=True,
+        )
+
+        assert (
+            nickname == expected_nickname
+        ), f"Expected nickname to be {expected_nickname}, got {nickname}"
+
+    @pytest.mark.asyncio_concurrent(group="nickname_generic_tests")
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            NicknameTestData(
+                nickname_template="{roblox-name}",
+                expected_nickname="{roblox_user.username}",
+                include_discord_user=True,
+                include_roblox_user=False,
+            ),
+        ],
+    )
+    async def test_shorter_nicknames_disabled(
+        self,
+        test_guild: "GuildSerializable",
+        test_group: RobloxGroup,
+        test_group_member_bracketed_roleset: MockUser,
+        test_case: NicknameTestData,
+        mocker: MockerFixture,
+    ):
+        """Test that templates with brackets are parsed with full roleset names if shorter nicknames are disabled."""
 
         expected_nickname = test_case.expected_nickname
         nickname_template = test_case.nickname_template


### PR DESCRIPTION
If `shorterNicknames` is enabled, then the returned nickname template will extract the text from the brackets instead of the full Roleset name. e.g. `[L1] Recruit` will just return `L1`.