### PR TITLE
Fixes

### DIFF
--- a/bloxlink_lib/models/base/iterables.py
+++ b/bloxlink_lib/models/base/iterables.py
@@ -65,7 +65,11 @@ class PydanticDict[K, V](RootModel[dict[K, V]]):
         return len(self.root)
 
     def __eq__(self, other) -> bool:
-        return self.root == other.root if isinstance(other, PydanticDict) else False
+        return (
+            self.root == PydanticDict(other).root
+            if isinstance(other, (PydanticDict, dict))
+            else False
+        )
 
     def __str__(self) -> str:
         return str(self.root)
@@ -125,7 +129,11 @@ class PydanticList[T](RootModel[list[T]]):
         return len(self.root)
 
     def __eq__(self, other) -> bool:
-        return self.root == other.root if isinstance(other, PydanticList) else False
+        return (
+            self.root == PydanticList(other).root
+            if isinstance(other, (PydanticList, list))
+            else False
+        )
 
     def __str__(self) -> str:
         return str(self.root)

--- a/bloxlink_lib/models/binds.py
+++ b/bloxlink_lib/models/binds.py
@@ -154,7 +154,6 @@ class GuildBind(BaseModel):
     highest_role: RoleSerializable | None = Field(
         exclude=True, default=None
     )  # highest role in the guild
-    migrated_bind: bool = Field(exclude=True, default=False)  # for v3 to v4 migration
 
     def model_post_init(self, __context):
         self.entity = self.entity or create_entity(self.criteria.type, self.criteria.id)
@@ -199,7 +198,6 @@ class GuildBind(BaseModel):
                 remove_roles=group_data.get("removeRoles") or [],
                 subtype="full_group",
                 data=BindData(displayName=group_data.get("groupName")),
-                migrated_bind=True,
             )
 
             converted_binds.append(new_bind)
@@ -240,7 +238,6 @@ class GuildBind(BaseModel):
                                 data=BindData(
                                     displayName=group_bind_data.get("groupName")
                                 ),
-                                migrated_bind=True,
                             )
 
                             converted_binds.append(new_bind)
@@ -261,7 +258,6 @@ class GuildBind(BaseModel):
                                 data=BindData(
                                     displayName=group_bind_data.get("groupName")
                                 ),
-                                migrated_bind=True,
                             )
 
                             converted_binds.append(new_bind)
@@ -283,7 +279,6 @@ class GuildBind(BaseModel):
                             remove_roles=bind_data.get("removeRoles") or [],
                             criteria=BindCriteria(type=bind_type, id=int(entity_id)),
                             data=BindData(displayName=bind_data.get("displayName")),
-                            migrated_bind=True,
                         )
 
                         converted_binds.append(new_bind)

--- a/bloxlink_lib/models/binds.py
+++ b/bloxlink_lib/models/binds.py
@@ -164,6 +164,16 @@ class GuildBind(BaseModel):
                 "full_group" if self.criteria.group.dynamicRoles else "role_bind"
             )
 
+    # Field migrators
+    @field_validator("nickname", mode="before")
+    @classmethod
+    def migrate_nickname(cls: Type[Self], nickname: str | None) -> str | None:
+        """Migrate the nickname field."""
+
+        from bloxlink_lib.models.migrators import migrate_nickname_template
+
+        return migrate_nickname_template(nickname)
+
     @classmethod
     def from_V3(cls: Type[Self], guild_data: GuildData | dict | V3RoleBinds):
         """Convert V3 binds to V4 binds."""

--- a/bloxlink_lib/models/binds.py
+++ b/bloxlink_lib/models/binds.py
@@ -154,6 +154,7 @@ class GuildBind(BaseModel):
     highest_role: RoleSerializable | None = Field(
         exclude=True, default=None
     )  # highest role in the guild
+    migrated_bind: bool = Field(exclude=True, default=False)  # for v3 to v4 migration
 
     def model_post_init(self, __context):
         self.entity = self.entity or create_entity(self.criteria.type, self.criteria.id)
@@ -198,6 +199,7 @@ class GuildBind(BaseModel):
                 remove_roles=group_data.get("removeRoles") or [],
                 subtype="full_group",
                 data=BindData(displayName=group_data.get("groupName")),
+                migrated_bind=True,
             )
 
             converted_binds.append(new_bind)
@@ -238,6 +240,7 @@ class GuildBind(BaseModel):
                                 data=BindData(
                                     displayName=group_bind_data.get("groupName")
                                 ),
+                                migrated_bind=True,
                             )
 
                             converted_binds.append(new_bind)
@@ -258,6 +261,7 @@ class GuildBind(BaseModel):
                                 data=BindData(
                                     displayName=group_bind_data.get("groupName")
                                 ),
+                                migrated_bind=True,
                             )
 
                             converted_binds.append(new_bind)
@@ -279,6 +283,7 @@ class GuildBind(BaseModel):
                             remove_roles=bind_data.get("removeRoles") or [],
                             criteria=BindCriteria(type=bind_type, id=int(entity_id)),
                             data=BindData(displayName=bind_data.get("displayName")),
+                            migrated_bind=True,
                         )
 
                         converted_binds.append(new_bind)

--- a/bloxlink_lib/models/migrators.py
+++ b/bloxlink_lib/models/migrators.py
@@ -4,6 +4,7 @@ from bloxlink_lib.models.schemas.guilds import (  # pylint: disable=no-name-in-m
     GuildRestriction,
 )
 from bloxlink_lib.models import BaseModel
+from bloxlink_lib.models.roblox.binds import RobloxUserNicknames
 from pydantic import ValidationInfo
 
 
@@ -164,3 +165,23 @@ def migrate_null_values(cls: BaseModel, v: str | None, info: ValidationInfo) -> 
         return cls.model_fields[info.field_name].get_default()
 
     return v
+
+
+def migrate_nickname_template(nickname_template: str | None) -> str | None:
+    """Migrate the nicknameTemplate field.
+
+    If the nicknameTemplate contains a Roblox user nickname template without the curly braces, add them.
+    """
+
+    if nickname_template is None:
+        return None
+
+    for template in RobloxUserNicknames:
+        if template.value in nickname_template and (
+            f"{{{template.value}}}" not in nickname_template
+        ):
+            nickname_template = nickname_template.replace(
+                template.value, f"{{{template.value}}}"
+            )
+
+    return nickname_template

--- a/bloxlink_lib/models/roblox/binds.py
+++ b/bloxlink_lib/models/roblox/binds.py
@@ -429,3 +429,32 @@ async def count_binds(guild_id: int | str, bind_id: int = None) -> int:
         if not bind_id
         else sum(1 for b in guild_data if b.id == int(bind_id)) or 0
     )
+
+
+async def delete_bind(
+    guild_id: int | str,
+    *remove_bind_hashes: int,
+):
+    """
+    Remove a bind from the database.
+
+    Args:
+        guild_id (int | str): ID of the guild.
+        *remove_bind_hashes (int): Hashes of the binds to remove. This can be found by calling hash() on the bind.
+    """
+
+    guild_binds = await get_binds(str(guild_id))
+
+    for bind_hash in remove_bind_hashes:
+        bind = find(lambda b: hash(b) == bind_hash, guild_binds)
+
+        if not bind:
+            raise ValueError(f"Bind not found: {bind_hash}")
+
+        guild_binds.remove(bind)
+
+    await update_guild_data(
+        guild_id,
+        binds=[b.model_dump(exclude_unset=True, by_alias=True) for b in guild_binds],
+        migratedBindsToV4=True,
+    )

--- a/bloxlink_lib/models/roblox/binds.py
+++ b/bloxlink_lib/models/roblox/binds.py
@@ -402,7 +402,7 @@ async def check_for_verified_roles(
     if new_verified_binds:
         merge_to.extend(new_verified_binds)
 
-        # if SAVE_NEW_BINDS: # TODO: this continuely appends the verifiedRoleName as a new bind
+        # if SAVE_NEW_BINDS: # TODO: BUG: this continuely appends the verifiedRoleName as a new bind
         #     await update_guild_data(
         #         guild_id,
         #         binds=[b.model_dump(exclude_unset=True, by_alias=True) for b in merge_to],

--- a/bloxlink_lib/models/roblox/binds.py
+++ b/bloxlink_lib/models/roblox/binds.py
@@ -433,14 +433,14 @@ async def count_binds(guild_id: int | str, bind_id: int = None) -> int:
 
 async def delete_bind(
     guild_id: int | str,
-    *remove_bind_hashes: int,
+    remove_bind_hashes: list[int],
 ):
     """
     Remove a bind from the database.
 
     Args:
         guild_id (int | str): ID of the guild.
-        *remove_bind_hashes (int): Hashes of the binds to remove. This can be found by calling hash() on the bind.
+        remove_bind_hashes (list[int]): Hashes of the binds to remove. This can be found by calling hash() on the bind.
     """
 
     guild_binds = await get_binds(str(guild_id))

--- a/bloxlink_lib/models/schemas/guilds.py
+++ b/bloxlink_lib/models/schemas/guilds.py
@@ -226,6 +226,19 @@ class GuildData(BaseSchema):
 
         return migrate_delete_commands(delete_commands)
 
+    @field_validator("nicknameTemplate", mode="before")
+    @classmethod
+    def transform_nickname_template(
+        cls: Type[Self], nickname_template: str | None
+    ) -> str:
+        """Migrate the nicknameTemplate field."""
+
+        from bloxlink_lib.models.migrators import (
+            migrate_nickname_template,
+        )
+
+        return migrate_nickname_template(nickname_template)
+
     @field_validator("createMissingRoles", mode="before")
     @classmethod
     def transform_create_missing_roles(

--- a/bloxlink_lib/models/v3_binds.py
+++ b/bloxlink_lib/models/v3_binds.py
@@ -1,6 +1,6 @@
 from typing import Literal, Optional, Annotated
 from pydantic import Field
-from bloxlink_lib.models.base import BaseModel
+from bloxlink_lib.models.base import BaseModel, PydanticDict
 
 V3BindType = Literal["groups", "assets", "badges", "gamePasses"]
 
@@ -26,7 +26,7 @@ class V3RangeBinding(BaseModel):
 class V3GroupBind(BaseModel):
     """Represents a group binding configuration."""
 
-    binds: dict[str | Literal["all"], V3RoleBind]
+    binds: PydanticDict[str | Literal["all"], V3RoleBind]
     ranges: Annotated[list[V3RangeBinding], Field(default_factory=list)]
     groupName: str
     removeRoles: list[str] = []
@@ -53,16 +53,13 @@ class V3RoleBinds(BaseModel):
     """Represents the role binds for a guild in the database."""
 
     roleBinds: Annotated[
-        dict[
-            V3BindType,
-            dict[str, V3GroupBind | V3AssetBind],
-        ],
-        Field(default_factory=dict),
-    ] = Field(default_factory=dict)
-    groupIDs: Annotated[dict[str, V3GroupID], Field(default_factory=dict)] = Field(
-        default_factory=dict
-    )
+        PydanticDict[V3BindType, PydanticDict[str, V3GroupBind | V3AssetBind]],
+        Field(default_factory=PydanticDict),
+    ] = Field(default_factory=PydanticDict)
+    groupIDs: Annotated[
+        PydanticDict[str, V3GroupID], Field(default_factory=PydanticDict)
+    ] = Field(default_factory=PydanticDict)
 
 
-V3RoleBindType = dict[V3BindType, dict[str, V3GroupBind | V3AssetBind]]
-V3GroupIDType = dict[str, V3GroupID]
+V3RoleBindType = PydanticDict[V3BindType, PydanticDict[str, V3GroupBind | V3AssetBind]]
+V3GroupIDType = PydanticDict[str, V3GroupID]

--- a/bloxlink_lib/models/v3_binds.py
+++ b/bloxlink_lib/models/v3_binds.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union, Annotated
+from typing import Literal, Optional, Annotated
 from pydantic import Field
 from bloxlink_lib.models.base import BaseModel
 
@@ -41,24 +41,6 @@ class V3AssetBind(BaseModel):
     roles: list[str]
 
 
-class V3BadgeBind(BaseModel):
-    """Represents a badge binding configuration."""
-
-    nickname: Optional[str] = None
-    displayName: str | None = None
-    removeRoles: Annotated[list[str], Field(default_factory=list)]
-    roles: list[str]
-
-
-class V3GamePassBind(BaseModel):
-    """Represents a game pass binding configuration."""
-
-    nickname: Optional[str] = None
-    displayName: str | None = None
-    removeRoles: Annotated[list[str], Field(default_factory=list)]
-    roles: list[str]
-
-
 class V3GroupID(BaseModel):
     """Represents a group ID configuration."""
 
@@ -70,11 +52,17 @@ class V3GroupID(BaseModel):
 class V3RoleBinds(BaseModel):
     """Represents the role binds for a guild in the database."""
 
-    roleBinds: (
+    roleBinds: Annotated[
         dict[
             V3BindType,
-            dict[str, Union[V3GroupBind, V3AssetBind, V3BadgeBind, V3GamePassBind]],
-        ]
-        | None
-    ) = None
-    groupIDs: dict[str, V3GroupID] | None = None
+            dict[str, V3GroupBind | V3AssetBind],
+        ],
+        Field(default_factory=dict),
+    ] = Field(default_factory=dict)
+    groupIDs: Annotated[dict[str, V3GroupID], Field(default_factory=dict)] = Field(
+        default_factory=dict
+    )
+
+
+V3RoleBindType = dict[V3BindType, dict[str, V3GroupBind | V3AssetBind]]
+V3GroupIDType = dict[str, V3GroupID]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,7 @@ from bloxlink_lib.database.redis import (  # pylint: disable=no-name-in-module
     wait_for_redis as wait_for_redis_,
 )
 from bloxlink_lib.database.mongodb import mongo
+from tests.shared import *
 
 TEST_GUILD_ID: Final[int] = 123
 

--- a/tests/integration/test_binds.py
+++ b/tests/integration/test_binds.py
@@ -2,15 +2,10 @@ import pytest
 from bloxlink_lib.models.roblox.binds import delete_bind, get_binds, count_binds
 from bloxlink_lib.models.schemas.guilds import (  # pylint: disable=no-name-in-module
     update_guild_data,
-    fetch_guild_data,
-    GuildData,
 )
-from bloxlink_lib.database.mongodb import _db_fetch, _db_update
-from bloxlink_lib.models.migrators import *
-from pydantic import ValidationError
 from tests.shared import BindConversionTestCase
 
-pytestmark = pytest.mark.database
+pytestmark = pytest.mark.binds
 
 
 class TestIntegrationV3BindRemovals:

--- a/tests/integration/test_binds.py
+++ b/tests/integration/test_binds.py
@@ -1,0 +1,115 @@
+import pytest
+from bloxlink_lib.models.roblox.binds import delete_bind, get_binds, count_binds
+from bloxlink_lib.models.schemas.guilds import (  # pylint: disable=no-name-in-module
+    update_guild_data,
+    fetch_guild_data,
+    GuildData,
+)
+from bloxlink_lib.database.mongodb import _db_fetch, _db_update
+from bloxlink_lib.models.migrators import *
+from pydantic import ValidationError
+from tests.shared import BindConversionTestCase
+
+pytestmark = pytest.mark.database
+
+
+class TestIntegrationV3BindRemovals:
+    """Tests the removal of V3 binds."""
+
+    @pytest.mark.asyncio
+    async def test_v3_group_bind_removal_all_binds(
+        self, test_guild_id: int, bind_conversion_test_data: BindConversionTestCase
+    ):
+        """Test the removal of a V3 group bind"""
+
+        v3_binds = bind_conversion_test_data.v3_binds
+
+        await update_guild_data(
+            test_guild_id,
+            roleBinds=v3_binds.roleBinds.model_dump(exclude_unset=True, by_alias=True),
+            groupIDs=v3_binds.groupIDs.model_dump(exclude_unset=True, by_alias=True),
+        )
+
+        merged_binds = await get_binds(test_guild_id)
+
+        await delete_bind(
+            guild_id=test_guild_id,
+            remove_bind_hashes=[hash(bind) for bind in merged_binds],
+        )
+
+        assert len(await get_binds(test_guild_id)) == 0
+
+    @pytest.mark.asyncio
+    async def test_v3_group_bind_removal_one_at_a_time(
+        self, test_guild_id: int, bind_conversion_test_data: BindConversionTestCase
+    ):
+        """Test the removal of a V3 group bind"""
+
+        v3_binds = bind_conversion_test_data.v3_binds
+
+        await update_guild_data(
+            test_guild_id,
+            roleBinds=v3_binds.roleBinds.model_dump(exclude_unset=True, by_alias=True),
+            groupIDs=v3_binds.groupIDs.model_dump(exclude_unset=True, by_alias=True),
+        )
+
+        merged_binds = await get_binds(test_guild_id)
+
+        for bind in list(merged_binds):
+            await delete_bind(
+                guild_id=test_guild_id,
+                remove_bind_hashes=[hash(bind)],
+            )
+
+            assert bind not in await get_binds(test_guild_id)
+
+    @pytest.mark.asyncio
+    async def test_v3_group_bind_removal_with_v4_binds(
+        self, test_guild_id: int, bind_conversion_test_data: BindConversionTestCase
+    ):
+        """Test the removal of a V3 group bind"""
+
+        v3_binds = bind_conversion_test_data.v3_binds
+        v4_binds = bind_conversion_test_data.v4_binds
+
+        await update_guild_data(
+            test_guild_id,
+            roleBinds=v3_binds.roleBinds.model_dump(exclude_unset=True, by_alias=True),
+            groupIDs=v3_binds.groupIDs.model_dump(exclude_unset=True, by_alias=True),
+            binds=v4_binds.model_dump(exclude_unset=True, by_alias=True),
+        )
+
+        merged_binds = await get_binds(test_guild_id)
+
+        for bind in list(merged_binds):
+            await delete_bind(
+                guild_id=test_guild_id,
+                remove_bind_hashes=[hash(bind)],
+            )
+
+            assert bind not in await get_binds(test_guild_id)
+
+    @pytest.mark.asyncio
+    async def test_v4_group_bind_removal(
+        self, test_guild_id: int, bind_conversion_test_data: BindConversionTestCase
+    ):
+        """Test the removal of a V4 group bind"""
+
+        v4_binds = bind_conversion_test_data.v4_binds
+
+        await update_guild_data(
+            test_guild_id,
+            binds=v4_binds.model_dump(exclude_unset=True, by_alias=True),
+        )
+
+        merged_binds = await get_binds(test_guild_id)
+
+        assert len(merged_binds) == len(v4_binds)
+
+        for bind in list(merged_binds):
+            await delete_bind(
+                guild_id=test_guild_id,
+                remove_bind_hashes=[hash(bind)],
+            )
+
+            assert bind not in await get_binds(test_guild_id)

--- a/tests/shared/__init__.py
+++ b/tests/shared/__init__.py
@@ -1,0 +1,1 @@
+from .bind_conversions import *

--- a/tests/shared/bind_conversions.py
+++ b/tests/shared/bind_conversions.py
@@ -1,13 +1,14 @@
 import pytest
 from bloxlink_lib.models import binds
 from bloxlink_lib.models.v3_binds import *
+from bloxlink_lib import PydanticList
 
 
 class BindConversionTestCase(BaseModel):
     """A test case for bind conversions. V3 binds must be converted to V4 binds."""
 
     v3_binds: V3RoleBinds
-    v4_binds: list[binds.GuildBind]
+    v4_binds: PydanticList[binds.GuildBind]
 
 
 @pytest.fixture(

--- a/tests/shared/bind_conversions.py
+++ b/tests/shared/bind_conversions.py
@@ -94,7 +94,7 @@ class BindConversionTestCase(BaseModel):
             v3_binds=V3RoleBinds(
                 groupIDs={
                     "1": V3GroupID(
-                        nickname="{roblox-name}-{group-rank}",
+                        nickname="roblox-name-group-rank",
                         groupName="Test Group 1",
                         removeRoles=[],
                     ),

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,2 +1,3 @@
 from bloxlink_lib.test_utils.fixtures import *
 from .fixtures import *  # pylint: disable=wildcard-import, unused-wildcard-import # makes fixtures available to all tests
+from tests.shared import *

--- a/tests/unit/fixtures/__init__.py
+++ b/tests/unit/fixtures/__init__.py
@@ -1,3 +1,2 @@
 from .binds import *
-from .bind_conversions import *
 from .nicknames import *

--- a/tests/unit/fixtures/bind_conversions.py
+++ b/tests/unit/fixtures/bind_conversions.py
@@ -168,7 +168,7 @@ class BindConversionTestCase(BaseModel):
                         )
                     },
                     "badges": {
-                        "2667428956752400": V3BadgeBind(
+                        "2667428956752400": V3AssetBind(
                             nickname=None,
                             displayName="Spiral Horns of the Developer",
                             removeRoles=[],
@@ -176,7 +176,7 @@ class BindConversionTestCase(BaseModel):
                         )
                     },
                     "gamePasses": {
-                        "824168675": V3GamePassBind(
+                        "824168675": V3AssetBind(
                             nickname="sdaasdsd",
                             displayName="Carry 1 Extra Item ",
                             removeRoles=[],

--- a/tests/unit/test_bind_conversions.py
+++ b/tests/unit/test_bind_conversions.py
@@ -1,6 +1,6 @@
 import pytest
 from bloxlink_lib.models import binds
-from tests.unit.fixtures.bind_conversions import BindConversionTestCase
+from tests.shared.bind_conversions import BindConversionTestCase
 
 
 pytestmark = pytest.mark.binds

--- a/tests/unit/test_migrators.py
+++ b/tests/unit/test_migrators.py
@@ -102,3 +102,28 @@ class TestVerifiedRoleMigrators:
         )
 
         assert test_guild_data.welcomeMessage == "Welcome to the server!"
+
+    @pytest.mark.parametrize(
+        "nickname_template",
+        [
+            ["roblox-name", "{roblox-name}"],
+            ["roblox-id", "{roblox-id}"],
+            ["{roblox-name}", "{roblox-name}"],
+            ["roblox-id {roblox-name}", "{roblox-id} {roblox-name}"],
+            ["[O1] group-rank", "[O1] {group-rank}"],
+        ],
+    )
+    @pytest.mark.asyncio_concurrent(group="migrators")
+    async def test_migrate_nickname_template(
+        self,
+        test_guild: GuildSerializable,
+        nickname_template: list[str],
+    ):
+        """Test the nickname template migrator"""
+
+        test_guild_data = GuildData(
+            id=test_guild.id,
+            nicknameTemplate=nickname_template[0],
+        )
+
+        assert test_guild_data.nicknameTemplate == nickname_template[1]

--- a/tests/unit/test_migrators.py
+++ b/tests/unit/test_migrators.py
@@ -111,6 +111,7 @@ class TestVerifiedRoleMigrators:
             ["{roblox-name}", "{roblox-name}"],
             ["roblox-id {roblox-name}", "{roblox-id} {roblox-name}"],
             ["[O1] group-rank", "[O1] {group-rank}"],
+            ["{test} {roblox-name}", "{test} {roblox-name}"],
         ],
     )
     @pytest.mark.asyncio_concurrent(group="migrators")


### PR DESCRIPTION
* Moves `delete_bind` from `bloxlink-http` to `bloxlink-lib`
* When binds are deleted, it will set `migratedBindsToV4` to `true` which will cause Bloxlink to not return those binds to the user, effectively soft-deleting them
* Migrates global and bind nicknames to include curly braces if the template does not have it