### PR TITLE
Fix bind hashes

### DIFF
--- a/bloxlink_lib/models/binds.py
+++ b/bloxlink_lib/models/binds.py
@@ -549,9 +549,7 @@ class GuildBind(BaseModel):
         )
 
     def __hash__(self) -> int:
-        return hash(
-            (self.criteria, tuple(self.roles), tuple(self.remove_roles), self.nickname)
-        )
+        return hash(self.criteria)
 
 
 async def build_binds_desc(

--- a/bloxlink_lib/models/migrators.py
+++ b/bloxlink_lib/models/migrators.py
@@ -220,5 +220,6 @@ def migrate_binds(guild_binds: list[GuildBind]) -> list[GuildBind]:
             binds_by_hash[bind_hash] = bind
         else:
             binds_by_hash[bind_hash].roles.extend(bind.roles)
+            binds_by_hash[bind_hash].remove_roles.extend(bind.remove_roles)
 
     return list(binds_by_hash.values())

--- a/bloxlink_lib/models/migrators.py
+++ b/bloxlink_lib/models/migrators.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Type
-from bloxlink_lib.models.binds import VALID_BIND_TYPES
+from bloxlink_lib.models.binds import GuildBind, VALID_BIND_TYPES
 from bloxlink_lib.models.schemas.guilds import (  # pylint: disable=no-name-in-module
     GuildRestriction,
 )
@@ -206,3 +206,19 @@ def migrate_nickname_template(nickname_template: str | None) -> str | None:
         nickname_template = nickname_template.replace(placeholder, original)
 
     return nickname_template
+
+
+def migrate_binds(guild_binds: list[GuildBind]) -> list[GuildBind]:
+    """Migrate the binds field. This will merge duplicate binds."""
+
+    binds_by_hash: dict[int, GuildBind] = {}
+
+    for bind in guild_binds:
+        bind_hash = hash(bind)
+
+        if bind_hash not in binds_by_hash:
+            binds_by_hash[bind_hash] = bind
+        else:
+            binds_by_hash[bind_hash].roles.extend(bind.roles)
+
+    return list(binds_by_hash.values())

--- a/bloxlink_lib/models/roblox/binds.py
+++ b/bloxlink_lib/models/roblox/binds.py
@@ -445,6 +445,9 @@ async def delete_bind(
 
     guild_binds = await get_binds(str(guild_id))
 
+    if guild_id == 1226265632950063196:
+        print("HASHES", [hash(b) for b in guild_binds], remove_bind_hashes)
+
     for bind_hash in remove_bind_hashes:
         bind = find(lambda b: hash(b) == bind_hash, guild_binds)
 

--- a/bloxlink_lib/models/roblox/binds.py
+++ b/bloxlink_lib/models/roblox/binds.py
@@ -445,9 +445,6 @@ async def delete_bind(
 
     guild_binds = await get_binds(str(guild_id))
 
-    if guild_id == 1226265632950063196:
-        print("HASHES", [hash(b) for b in guild_binds], remove_bind_hashes)
-
     for bind_hash in remove_bind_hashes:
         bind = find(lambda b: hash(b) == bind_hash, guild_binds)
 

--- a/bloxlink_lib/models/schemas/guilds.py
+++ b/bloxlink_lib/models/schemas/guilds.py
@@ -208,10 +208,17 @@ class GuildData(BaseSchema):
     def transform_binds(cls: Type[Self], binds: list) -> list[GuildBind]:
         """Transforms DB binds to GuildBinds"""
 
-        if all(isinstance(b, GuildBind) for b in binds):
-            return binds
+        from bloxlink_lib.models.migrators import (
+            migrate_binds,
+        )
 
-        return [GuildBind(**b) for b in binds]
+        guild_binds = (
+            binds
+            if all(isinstance(b, GuildBind) for b in binds)
+            else [GuildBind(**b) for b in binds]
+        )
+
+        return migrate_binds(guild_binds)
 
     @field_validator("deleteCommands", mode="before")
     @classmethod

--- a/tests/unit/test_migrators.py
+++ b/tests/unit/test_migrators.py
@@ -1,7 +1,11 @@
 import pytest
 from bloxlink_lib import GuildData, GuildSerializable
+from bloxlink_lib.models.binds import BindCriteria, GuildBind, GroupBindData
 
 pytestmark = pytest.mark.database
+
+
+TEST_GROUP_ID = 1337
 
 
 class TestVerifiedRoleMigrators:
@@ -136,3 +140,86 @@ class TestVerifiedRoleMigrators:
         )
 
         assert test_guild_data.nicknameTemplate == nickname_template[1]
+
+    @pytest.mark.asyncio_concurrent(group="migrators")
+    async def test_migrate_binds(self, test_guild: GuildSerializable):
+        """Test the binds migrator"""
+
+        test_guild_data = GuildData(
+            id=1,
+            binds=[
+                GuildBind(
+                    criteria=BindCriteria(
+                        type="group",
+                        id=TEST_GROUP_ID,
+                        group=GroupBindData(
+                            dynamicRoles=True,
+                        ),
+                    ),
+                    roles=["123"],
+                ),
+                GuildBind(
+                    criteria=BindCriteria(
+                        type="group",
+                        id=TEST_GROUP_ID,
+                        group=GroupBindData(
+                            dynamicRoles=True,
+                        ),
+                    ),
+                    roles=["567"],
+                ),
+                GuildBind(
+                    criteria=BindCriteria(
+                        type="group",
+                        id=TEST_GROUP_ID,
+                        group=GroupBindData(
+                            everyone=True,
+                        ),
+                    ),
+                    roles=["123"],
+                ),
+                GuildBind(
+                    criteria=BindCriteria(
+                        type="group",
+                        id=TEST_GROUP_ID + 1,
+                        group=GroupBindData(
+                            everyone=True,
+                        ),
+                    ),
+                    roles=[],
+                ),
+            ],
+        )
+
+        assert test_guild_data.binds == [
+            GuildBind(
+                criteria=BindCriteria(
+                    type="group",
+                    id=TEST_GROUP_ID,
+                    group=GroupBindData(
+                        dynamicRoles=True,
+                    ),
+                ),
+                roles=["123", "567"],
+            ),
+            GuildBind(
+                criteria=BindCriteria(
+                    type="group",
+                    id=TEST_GROUP_ID,
+                    group=GroupBindData(
+                        everyone=True,
+                    ),
+                ),
+                roles=["123"],
+            ),
+            GuildBind(
+                criteria=BindCriteria(
+                    type="group",
+                    id=TEST_GROUP_ID + 1,
+                    group=GroupBindData(
+                        everyone=True,
+                    ),
+                ),
+                roles=[],
+            ),
+        ]

--- a/tests/unit/test_migrators.py
+++ b/tests/unit/test_migrators.py
@@ -1,3 +1,4 @@
+from typing import Final
 import pytest
 from bloxlink_lib import GuildData, GuildSerializable
 from bloxlink_lib.models.binds import BindCriteria, GuildBind, GroupBindData
@@ -5,7 +6,7 @@ from bloxlink_lib.models.binds import BindCriteria, GuildBind, GroupBindData
 pytestmark = pytest.mark.database
 
 
-TEST_GROUP_ID = 1337
+TEST_GROUP_ID: Final[int] = 1337
 
 
 class TestVerifiedRoleMigrators:

--- a/tests/unit/test_migrators.py
+++ b/tests/unit/test_migrators.py
@@ -157,6 +157,7 @@ class TestVerifiedRoleMigrators:
                         ),
                     ),
                     roles=["123"],
+                    remove_roles=["777"],
                 ),
                 GuildBind(
                     criteria=BindCriteria(
@@ -167,6 +168,7 @@ class TestVerifiedRoleMigrators:
                         ),
                     ),
                     roles=["567"],
+                    remove_roles=["888"],
                 ),
                 GuildBind(
                     criteria=BindCriteria(
@@ -201,6 +203,7 @@ class TestVerifiedRoleMigrators:
                     ),
                 ),
                 roles=["123", "567"],
+                remove_roles=["777", "888"],
             ),
             GuildBind(
                 criteria=BindCriteria(


### PR DESCRIPTION
An issue occurred where the mutable `roles` list was causing binds to have different hashes.
This PR changes it so that a bind is considered to be the same as another bind if and only if the `criteria` is the same for both.

This PR also merges the roles of the duplicate binds.